### PR TITLE
Fixing DV when reminder value 10.

### DIFF
--- a/src/main/java/com/josketres/rfcfacil/VerificationDigitCalculator.java
+++ b/src/main/java/com/josketres/rfcfacil/VerificationDigitCalculator.java
@@ -69,10 +69,14 @@ class VerificationDigitCalculator {
         int reminder = sum % 11;
         if (reminder == 0) {
             return "0";
-        } else if (reminder == 10) {
-            return "A";
         } else {
-            return String.valueOf(11 - reminder);
+            int result = 11 - reminder;
+
+            if (result == 10) {
+                return "A";
+            } else {
+                return String.valueOf(11 - reminder);
+            }
         }
     }
 

--- a/src/test/java/com/josketres/rfcfacil/RfcTest.java
+++ b/src/test/java/com/josketres/rfcfacil/RfcTest.java
@@ -21,6 +21,31 @@ public class RfcTest {
         assertThat(rfc.homoclave, equalTo("CK"));
         assertThat(rfc.verificationDigit, equalTo("6"));
         assertThat(rfc.toString(), equalTo("ZATJ870805CK6"));
+
+        rfc = new Rfc.Builder()
+                .name("ELIUD")
+                .firstLastName("OROZCO")
+                .secondLastName("GOMEZ")
+                .birthday(11, 7, 1952)
+                .build();
+
+        assertThat(rfc.tenDigitsCode, equalTo("OOGE520711"));
+        assertThat(rfc.homoclave, equalTo("15"));
+        assertThat(rfc.verificationDigit, equalTo("1"));
+        assertThat(rfc.toString(), equalTo("OOGE520711151"));
+
+        rfc = new Rfc.Builder()
+                .name("SATURNINA")
+                .firstLastName("ANGEL")
+                .secondLastName("CRUZ")
+                .birthday(12, 11, 1921)
+                .build();
+
+        assertThat(rfc.tenDigitsCode, equalTo("AECS211129"));
+        assertThat(rfc.homoclave, equalTo("JP"));
+        assertThat(rfc.verificationDigit, equalTo("A"));
+        assertThat(rfc.toString(), equalTo("AECS211129JPA"));
+
     }
 
     @Test


### PR DESCRIPTION
Before to replace the reminder value to "A" when the reminder value is
greather than 0, first need to apply the arithmetic rest of 11 factor
minus the reminder value, then validate if the value of the result is
10, replace it with "A", else, return string value of the result.

With these change, i can validate a few of RFC.

I have added some examples to be validated, when reminder values is 10
and 1.